### PR TITLE
Added Installation Steps Prompts

### DIFF
--- a/generated-readmes/installtest.md
+++ b/generated-readmes/installtest.md
@@ -1,0 +1,36 @@
+# Install Test
+
+## Description
+
+* Testing install
+
+### What was my motivation?
+
+* test
+
+### Why did you build this project?
+
+* test
+
+### What problem does this solve?
+
+* test
+
+### What have I learned from this project?
+
+*test
+
+## Installation:
+
+* Step 1
+* Step 2
+* Step 3
+
+## Usage:
+
+* None
+
+## Credits:
+
+* None
+        

--- a/generated-readmes/test2.md
+++ b/generated-readmes/test2.md
@@ -1,0 +1,35 @@
+# Testing
+
+## Description
+
+* Test
+
+### What was my motivation?
+
+* test
+
+### Why did you build this project?
+
+* test
+
+### What problem does this solve?
+
+* test
+
+### What have I learned from this project?
+
+*test
+
+## Installation:
+
+* STEP 1
+* STEP 2
+
+## Usage:
+
+* test
+
+## Credits:
+
+* test
+        

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const createREADME = `# ${data.title}
 
 ### What have I learned from this project?
 
-*${data.learned}
+* ${data.learned}
 
 ## Installation:
 

--- a/index.js
+++ b/index.js
@@ -40,9 +40,16 @@ inquirer
             name: 'learned',
         },
         {
-            type: 'input',
-            message: 'Installation',
-            name: 'installation',
+            type: 'list',
+            message: 'Does this project require any installations?',
+            name: 'installConfirm',
+            choices: ['Yes', 'No'],
+            validate: function (value) {
+                if (value !== 'Yes' && value !== 'No') {
+                    return 'Please select either "Yes" or "No"';
+                }
+                return true;
+            },
         },
         {
             type: 'input',
@@ -54,8 +61,43 @@ inquirer
             message: 'Credits',
             name: 'credits',
         }
-    ]) .then(data => {
-        const createREADME = `# ${data.title}
+    ])
+    .then(data => {
+        // If the user selected "Yes" to add required installation steps, calls function to add installation steps.
+        if (data.installConfirm === "Yes") {
+            data.installation = []
+            promptInstallationSteps(data);
+        } else {
+            // If the user did not select "Yes", this saves the file as is.
+            saveREADME(data);
+        }
+    })
+
+//prompts the user to add each step necessary for installation.
+function promptInstallationSteps(data) {
+    inquirer
+        .prompt({
+            type: 'input',
+            message: 'Please add an installation step (Enter "NO" to exit):',
+            name: 'installStep',
+        })
+        .then((installData) => {
+            // If the user originally selected or proceeded to input "NO", this saves the file at this point.
+            if (installData.installStep.toLowerCase() === 'no') {
+                saveREADME(data);
+            } else {
+                // If the user did not originally select "NO", and has not inputed "NO" it continues to prompt for more steps.
+                data.installation.push(installData.installStep);
+                promptInstallationSteps(data);
+            }
+        })
+}
+
+// This function takes and assembles the inputed data into the necessary positions.
+function saveREADME(data) {
+
+// The literal string positions the elements exactly where they need to be on the page.
+const createREADME = `# ${data.title}
 
 ## Description
 
@@ -79,7 +121,7 @@ inquirer
 
 ## Installation:
 
-* ${data.installation}
+${data.installation.length > 0 ? data.installation.map(step => `* ${step}`).join('\n') : 'No installation steps provided.'}
 
 ## Usage:
 
@@ -89,15 +131,22 @@ inquirer
 
 * ${data.credits}
         `;
+        // Defines the path for the save folder.
         const saveFolder = './generated-readmes';
+        // takes the name input and appends the ".md" file type for a markdown file.
         const fileName = `${data.filename.toLowerCase().split(' ').join('')}.md`;
 
+        // Checks if the file exists and creates it if it doesn't.
         if (!fs.existsSync(saveFolder)) {
             fs.mkdirSync(saveFolder);
         }
 
+        // Sets the desired path name to save the folder to.
         const filePath = path.join(saveFolder, fileName);
 
+        // Writes to the filepath and sets the file content using the generated structure.
         fs.writeFile(filePath, createREADME, (err) =>
         err ? console.error(err) : console.log('Success!'));
-    });
+
+    }
+


### PR DESCRIPTION
This PR adds in functionality where if the user selects "Yes" for required installations question, it will prompt the user to add in each step 1 by 1 and have it appended to a list under the Installation section. 

If the user types "NO" then the loop to add more steps ends and the file is saved
**WIP** Will likely change this to "exit". Currently it is tied to the "NO" from the question prompt, I will try detach and separate it with the "exit" input.

If the user selected "NO" the file will be saved and the prompt to input steps is skipped.